### PR TITLE
Fix startup script for IPs including 80

### DIFF
--- a/package/initd/gluu-server
+++ b/package/initd/gluu-server
@@ -92,7 +92,7 @@ PIDFILE=/var/run/gluu-server-$GLUU_VERSION.pid
 STAT=(`df -aP |grep \/opt\/gluu-server-$GLUU_VERSION\/ | awk '{ print $6 }' | grep -Eohw 'proc|lo|pts|modules|dev'`)
 
 start() {
-	PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eohw '80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211'`
+  PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'`
 	if [ -f $PIDFILE ] && [ ${#STAT[@]} = "6" ]; then
 		PID=`cat $PIDFILE`
                 echo "gluu-server-$GLUU_VERSION is already running"

--- a/package/systemd/gluu-serverd
+++ b/package/systemd/gluu-serverd
@@ -3,7 +3,7 @@
 GLUU_VERSION=3.0.0
 
 ready() {
-	PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eohw '80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211'`
+  PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'`
     	STAT=(`df -aP |grep \/opt\/gluu-server-$GLUU_VERSION\/ | awk '{ print $6 }' | grep -Eohw 'proc|lo|pts|modules|dev'`)
     	if [ -f $PIDFILE ] && [ ${#STAT[@]} = "6" ]; then
             PID=`cat $PIDFILE`


### PR DESCRIPTION
Hi! I don't know if you accept PRs but this script wouldn't run the service my server since it the grep was picking up my IP address ending in 80 as meaning a service was running on port 80. This fix stops that happening.