### PR TITLE
Fixed bug copying resolv.conf on systems with resolvconf

### DIFF
--- a/package/initd/gluu-server
+++ b/package/initd/gluu-server
@@ -108,7 +108,11 @@ start() {
  		echo "Starting Gluu server, please wait..."    	
 
                 if [ -f $RESOLV_CONF ]; then
-                        cp --parents -f $RESOLV_CONF /opt/gluu-server-$GLUU_VERSION/
+                        local target_resolv_conf=/opt/gluu-server-${GLUU_VERSION}/${RESOLV_CONF}
+                        if [ -h "${target_resolv_conf}" ]; then
+                                rm "${target_resolv_conf}"
+                        fi
+                        cp --parents -f $RESOLV_CONF -H /opt/gluu-server-$GLUU_VERSION/
                 fi
 	
 		/bin/mount /dev                    /opt/gluu-server-$GLUU_VERSION/dev -o bind


### PR DESCRIPTION
- use cp -H to de-reference the link target when copying resolv.conf.
  This makes the code work for systems using resolveconf (since these
  mantain /etc/resolv.conf being a link to
  /etc/resolvconf/run/resolv.conf) and the ones using a static
  /etc/resolv.conf alike.

- if there's already a symbolic link to /etc/resolv.conf in
  /opt/gluu-server-<version>/etc, cp -f will not (forcefully)
  overwrite it (since it's the same file). We therefore need to delete
  such links.

- Tested on the latest Debian stable, v9, with resolvconf installed (and a
  messed up, dangling resolv.conf link because of the mentioned bug).