### PR TITLE
Fix startup script: Wrong regular expression for port checking

### DIFF
--- a/package/initd/gluu-server
+++ b/package/initd/gluu-server
@@ -92,7 +92,7 @@ PIDFILE=/var/run/gluu-server-$GLUU_VERSION.pid
 STAT=(`df -aP |grep \/opt\/gluu-server-$GLUU_VERSION\/ | awk '{ print $6 }' | grep -Eohw 'proc|lo|pts|modules|dev'|sort|uniq`)
 
 start() {
-	PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eoh ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|8091|1389|1689|11211)'`
+	PORTS=`netstat -tunpl | awk '{ print $4 }' |grep -Eoh ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|8091|1389|1689|11211)$'`
 	if [ -f $PIDFILE ] && [ ${#STAT[@]} = "5" ]; then
 		PID=`cat $PIDFILE`
                 echo "gluu-server-$GLUU_VERSION is already running"

--- a/package/systemd/gluu-serverd
+++ b/package/systemd/gluu-serverd
@@ -3,7 +3,7 @@
 GLUU_VERSION=3.1.0
 
 ready() {
-  PORTS=`ss -tunpl | awk '{ print $5 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'$`
+  PORTS=`ss -tunpl | awk '{ print $5 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'`
     	STAT=(`df -aP |grep \/opt\/gluu-server-$GLUU_VERSION\/ | awk '{ print $6 }' | grep -Eohw 'proc|lo|pts|modules|dev'`)
     	if [ -f $PIDFILE ] && [ ${#STAT[@]} = "6" ]; then
             PID=`cat $PIDFILE`

--- a/package/systemd/gluu-serverd
+++ b/package/systemd/gluu-serverd
@@ -3,7 +3,7 @@
 GLUU_VERSION=3.1.0
 
 ready() {
-  PORTS=`ss -tunpl | awk '{ print $5 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'`
+  PORTS=`ss -tunpl | awk '{ print $5 }' |grep -Eohw ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|1389|1689|11211)'$`
     	STAT=(`df -aP |grep \/opt\/gluu-server-$GLUU_VERSION\/ | awk '{ print $6 }' | grep -Eohw 'proc|lo|pts|modules|dev'`)
     	if [ -f $PIDFILE ] && [ ${#STAT[@]} = "6" ]; then
             PID=`cat $PIDFILE`


### PR DESCRIPTION
This regular expression for checking services running on specific ports gives wrong results. This is fixed by making the regular expression matches only the end of the string.

```bash
$ echo ":8012312123123123123" | grep -Eoh ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|8091|1389|1689|11211)' 
:80
$ echo ":8012312123123123123" | grep -Eoh ':(80|443|8080|8081|8082|8083|8084|8085|8086|8090|8091|1389|1689|11211)$' 
$
```